### PR TITLE
refactor: add CSS color variables and apply across codebase

### DIFF
--- a/src/features/SnippetEditRow.jsx
+++ b/src/features/SnippetEditRow.jsx
@@ -17,7 +17,6 @@ function SnippetEditRow({
         onChange={(e) =>
           setEditFields({ ...editFields, practiceType: e.target.value })
         }
-        className="practiceTypeEditSelect"
         required
       >
         <option value="">-</option>

--- a/src/features/SnippetEditRow.module.css
+++ b/src/features/SnippetEditRow.module.css
@@ -1,19 +1,19 @@
 .cancelEditButton:enabled:hover {
-  border-color: #b40d0d;
-  /* border-width: 0.15em; */
+  border-color: var(--color-red);
 }
+
 .cancelEditButton:focus,
 .cancelEditButton:focus-visible {
-  outline: 4px auto #b40d0d;
-  box-shadow: 0 0 0 3px #7e0909;
+  outline: 4px auto var(--color-red);
+  box-shadow: 0 0 0 3px var(--color-accent-red);
 }
 
 .saveEditButton:enabled:hover {
-  border-color: #09c043;
-  /* border-width: 0.15em; */
+  border-color: var(--color-success);
 }
+
 .saveEditButton:focus,
 .saveEditButton:focus-visible {
-  outline: 4px auto #09c043;
-  box-shadow: 0 0 0 3px #068e31;
+  outline: 4px auto var(--color-success);
+  box-shadow: 0 0 0 3px var(--color-accent-green);
 }

--- a/src/features/SnippetList.jsx
+++ b/src/features/SnippetList.jsx
@@ -32,7 +32,7 @@ function SnippetList({
               <>
                 <input
                   type="checkbox"
-                  className="checkboxItem"
+                  aria-label="Mark as complete"
                   checked={false}
                   onChange={() => onComplete(snippet.id)}
                   disabled={isSaving}

--- a/src/features/SnippetList.module.css
+++ b/src/features/SnippetList.module.css
@@ -11,12 +11,12 @@
   gap: 0.5rem;
   margin-bottom: 0.75em;
   padding: 0.5em 1.25em;
-  background-color: #393939;
+  background-color: var(--color-snippet);
   border-radius: 10px;
 }
 
 .snippetList li:hover {
-  background-color: #464545;
+  background-color: var(--color-snippet-hover);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.75);
   transition:
     background-color 0.2s,

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,20 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color-scheme: light dark;
+
+  /* Dark Mode Default Colors */
+  --color-background: #242424;
+  --color-text: #ffffffde;
+  --color-gold: #a79242;
+  --color-accent-gold: #72601d;
+  --color-red: #b40d0d;
+  --color-accent-red: #7e0909;
+  --color-success: #09c043;
+  --color-accent-green: #068e31;
+  --color-link: #141414;
+  --color-snippet: #393939;
+  --color-snippet-hover: #464545;
+  --color-button-background: #191919;
 }
 
 body {

--- a/src/pages/NotFoundPage.jsx
+++ b/src/pages/NotFoundPage.jsx
@@ -6,8 +6,8 @@ function NotFoundPage() {
   return (
     <div>
       <h2>404 - Not Found</h2>
-      <h3>*Sad Trombone*</h3>
-      <p className={styles.womp}>womp womp wommmp</p>
+      <h3 className={styles.trombone}>*Sad Trombone*</h3>
+      <p className={styles.womp}>womp womp wommmp :(</p>
       <Link to="/" className={styles.backHome}>
         Back to Home
       </Link>

--- a/src/pages/NotFoundPage.module.css
+++ b/src/pages/NotFoundPage.module.css
@@ -1,8 +1,13 @@
 .womp {
-  color: rgb(255, 101, 127);
+  font-weight: 400;
+}
+
+.trombone {
   font-weight: 500;
 }
 
 .backHome {
+  color: var(--color-success);
   text-decoration: underline;
+  font-weight: 500;
 }

--- a/src/pages/PracticeForm.jsx
+++ b/src/pages/PracticeForm.jsx
@@ -32,7 +32,6 @@ function PracticeForm() {
     setGoal(e.target.value);
   }
 
-  // 1. function for adding an entire practice snippet
   async function addSnippet(newSnippet) {
     const payload = {
       records: [
@@ -100,7 +99,6 @@ function PracticeForm() {
     [practiceType, goal, metronome, timeSpent]
   );
 
-  // 2. useEffect to fetchAllSnippets when App starts
   useEffect(() => {
     async function fetchAllSnippets() {
       setIsLoading(true);
@@ -136,7 +134,6 @@ function PracticeForm() {
     fetchAllSnippets();
   }, []);
 
-  // 3. Update Snippet
   async function updateSnippet(editedSnippet) {
     const originalSnippet = allSnippets.find(
       (snippet) => snippet.id === editedSnippet.id
@@ -204,7 +201,6 @@ function PracticeForm() {
     setEditFields({});
   }
 
-  // 4. Complete a practice snippet
   async function completeSnippet(id) {
     const options = {
       method: 'PATCH',
@@ -341,14 +337,3 @@ function PracticeForm() {
 }
 
 export default PracticeForm;
-
-// TASKS:
-// Add feedback to user behavior ("Please fill all fields to submit");
-
-// Style with flexbox
-// Add accessibility
-
-// Stretch Goals
-// Add sorting for each of the 4 fields
-// Add a way for users to delete a snippet
-// Cache Result of API call so it doesn't call everytime

--- a/src/pages/PracticeForm.module.css
+++ b/src/pages/PracticeForm.module.css
@@ -18,8 +18,18 @@
   margin-bottom: 0.75rem;
 }
 
+.submitButton:enabled:hover {
+  border-color: var(--color-success);
+}
+
+.submitButton:focus,
+.submitButton:focus-visible {
+  outline: 4px auto var(--color-success);
+  box-shadow: 0 0 0 3px var(--color-accent-green);
+}
+
 .successMessage {
-  color: #09c043;
+  color: var(--color-success);
   margin-top: 1em;
   font-weight: 500;
 }

--- a/src/shared/GeneralButton.module.css
+++ b/src/shared/GeneralButton.module.css
@@ -5,7 +5,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-button-background);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.14);
   cursor: pointer;
   transition:
@@ -20,11 +20,11 @@ button:disabled {
 }
 
 button:enabled:hover {
-  border-color: #c8b04f;
+  border-color: var(--color-gold);
 }
 
 button:focus,
 button:focus-visible {
-  outline: 4px auto #c8b04f;
-  box-shadow: 0 0 0 3px #72601d;
+  outline: 4px auto var(--color-gold);
+  box-shadow: 0 0 0 3px var(--color-accent-gold);
 }

--- a/src/shared/NavBar.module.css
+++ b/src/shared/NavBar.module.css
@@ -3,8 +3,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background-color: #a79242;
-  border-bottom: 3px solid #b40d0d;
+  background-color: var(--color-gold);
+  border-bottom: 3px solid var(--color-red);
   border-radius: 0.75em;
   margin-bottom: 1em;
   padding: 0.4em 0;
@@ -20,14 +20,14 @@
 
 .link {
   color: #141414;
-  text-shadow: 1px 1px #72601d;
+  text-shadow: 1px 1px var(--color-accent-gold);
   font-size: 1.05em;
   font-weight: 500;
   text-decoration: none;
 }
 
 .link:hover {
-  color: #b40d0d;
+  color: var(--color-red);
   transition:
     background 0.2s,
     color 0.2s;


### PR DESCRIPTION
This PR refactors the project's styling by adding CSS custom property variables in the :root selector. All hard-coded values throughout the app have been replaced with these variables for easier maintainability. This prepares the codebase to support both dark and light modes.

- Added all main color as CSS variables in :root
- Replaced hard-coded color values with variables
- Improved maintainability and scalability for future theming